### PR TITLE
rotatelogs: add an option to generate log file name with timestemp

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,21 @@ already exists, an implicit rotation is performed.
   )
 ```
 
+## TimeBased
+
+The filename pattern should include `%H`, `%M` and `%S`. The suffix .1 .2 .3, etc,.
+would be omitted.
+
+```go
+  rotatelogs.New(
+    "/var/log/myapp/log.%Y%m%d-%H%M%S",
+    rotatelogs.TimeBased(),
+  )
+```
+
+The filename of log file would be: `/var/log/myapp/log.20240806-080523`,
+ `/var/log/myapp/log.20240806-092159`...
+
 # Rotating files forcefully
 
 If you want to rotate files forcefully before the actual rotation time has reached,

--- a/fileutil.go
+++ b/fileutil.go
@@ -29,14 +29,38 @@ func GenerateFn(pattern *strftime.Strftime, clock interface{ Now() time.Time }, 
 	// the local zone
 	var base time.Time
 	if now.Location() != time.UTC {
-		base = time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), now.Second(), now.Nanosecond(), time.UTC)
+		base = time.Date(
+			now.Year(),
+			now.Month(),
+			now.Day(),
+			now.Hour(),
+			now.Minute(),
+			now.Second(),
+			now.Nanosecond(),
+			time.UTC,
+		)
 		base = base.Truncate(rotationTime)
-		base = time.Date(base.Year(), base.Month(), base.Day(), base.Hour(), base.Minute(), base.Second(), base.Nanosecond(), base.Location())
+		base = time.Date(
+			base.Year(),
+			base.Month(),
+			base.Day(),
+			base.Hour(),
+			base.Minute(),
+			base.Second(),
+			base.Nanosecond(),
+			base.Location(),
+		)
 	} else {
 		base = now.Truncate(rotationTime)
 	}
 
 	return pattern.FormatString(base)
+}
+
+// GenerateNowFn creates a file name based on the pattern and the current time.
+func GenerateNowFn(pattern *strftime.Strftime, clock interface{ Now() time.Time }) string {
+	now := clock.Now()
+	return pattern.FormatString(now)
 }
 
 // CreateFile creates a new file in the given path, creating parent directories

--- a/fileutil_test.go
+++ b/fileutil_test.go
@@ -36,6 +36,35 @@ func TestGenerateFn(t *testing.T) {
 	}
 }
 
+func TestGenerateNowFn(t *testing.T) {
+	// Mock time
+	ts := []time.Time{
+		{},
+		(time.Time{}).Add(24 * time.Hour),
+		(time.Time{}).Add(25*time.Hour + 55*time.Minute + 15*time.Second),
+	}
+
+	for _, xt := range ts {
+		pattern, err := strftime.New("/path/to/%Y/%m/%d/%H/%M/%S")
+		if !assert.NoError(t, err, `strftime.New should succeed`) {
+			return
+		}
+		fn := GenerateNowFn(pattern, NewClock(xt))
+		expected := fmt.Sprintf("/path/to/%04d/%02d/%02d/%02d/%02d/%02d",
+			xt.Year(),
+			xt.Month(),
+			xt.Day(),
+			xt.Hour(),
+			xt.Minute(),
+			xt.Second(),
+		)
+
+		if !assert.Equal(t, expected, fn) {
+			return
+		}
+	}
+}
+
 func TestCreateFileSuccess(t *testing.T) {
 	file, err := CreateFile("testfile.log")
 	assert.NoError(t, err)

--- a/interface.go
+++ b/interface.go
@@ -48,6 +48,7 @@ type RotateLogs struct {
 	rotationSize  int64
 	rotationCount uint
 	forceNewFile  bool
+	timeBased     bool
 }
 
 // Clock is the interface used by the RotateLogs

--- a/options.go
+++ b/options.go
@@ -15,6 +15,7 @@ const (
 	optkeyRotationSize  = "rotation-size"
 	optkeyRotationCount = "rotation-count"
 	optkeyForceNewFile  = "force-new-file"
+	optkeyTimeBased     = "time-based"
 )
 
 // WithClock creates a new Option that sets a clock
@@ -86,4 +87,8 @@ func WithHandler(h Handler) Option {
 // rotation is performed
 func ForceNewFile() Option {
 	return option.New(optkeyForceNewFile, true)
+}
+
+func TimeBased() Option {
+	return option.New(optkeyTimeBased, true)
 }

--- a/rotatelogs_test.go
+++ b/rotatelogs_test.go
@@ -51,7 +51,14 @@ func TestLogRotate(t *testing.T) {
 				expectedLinkDest := filepath.Base(rl.CurrentFileName())
 				t.Logf("expecting relative link: %s", expectedLinkDest)
 
-				return assert.Equal(t, linkDest, expectedLinkDest, `Symlink destination should  match expected filename (%#v != %#v)`, expectedLinkDest, linkDest)
+				return assert.Equal(
+					t,
+					linkDest,
+					expectedLinkDest,
+					`Symlink destination should  match expected filename (%#v != %#v)`,
+					expectedLinkDest,
+					linkDest,
+				)
 			},
 		},
 		{
@@ -71,7 +78,14 @@ func TestLogRotate(t *testing.T) {
 				expectedLinkDest := filepath.Join("..", "..", filepath.Base(rl.CurrentFileName()))
 				t.Logf("expecting relative link: %s", expectedLinkDest)
 
-				return assert.Equal(t, linkDest, expectedLinkDest, `Symlink destination should  match expected filename (%#v != %#v)`, expectedLinkDest, linkDest)
+				return assert.Equal(
+					t,
+					linkDest,
+					expectedLinkDest,
+					`Symlink destination should  match expected filename (%#v != %#v)`,
+					expectedLinkDest,
+					linkDest,
+				)
 			},
 		},
 	}
@@ -337,7 +351,7 @@ func TestGHIssue16(t *testing.T) {
 
 	rl, err := New(
 		filepath.Join(dir, "log%Y%m%d%H%M%S"),
-		WithLinkName("./test.log"),
+		WithLinkName(filepath.Join(dir, "test.log")),
 		WithRotationTime(10*time.Second),
 		WithRotationCount(3),
 		WithMaxAge(-1),
@@ -379,7 +393,11 @@ func TestRotationGenerationalNames(t *testing.T) {
 			// and the previous files already exist, the filenames should share
 			// the same prefix and have a unique suffix
 			fn := filepath.Base(rl.CurrentFileName())
-			if !assert.True(t, strings.HasPrefix(fn, "unchanged-pattern.log"), "prefix for all filenames should match") {
+			if !assert.True(
+				t,
+				strings.HasPrefix(fn, "unchanged-pattern.log"),
+				"prefix for all filenames should match",
+			) {
 				return
 			}
 			_, _ = rl.Write([]byte("Hello, World!"))
@@ -391,7 +409,13 @@ func TestRotationGenerationalNames(t *testing.T) {
 			assert.FileExists(t, rl.CurrentFileName(), "file does not exist %s", rl.CurrentFileName())
 			stat, err := os.Stat(rl.CurrentFileName())
 			if err == nil {
-				if !assert.True(t, stat.Size() == 13, "file %s size is %d, expected 13", rl.CurrentFileName(), stat.Size()) {
+				if !assert.True(
+					t,
+					stat.Size() == 13,
+					"file %s size is %d, expected 13",
+					rl.CurrentFileName(),
+					stat.Size(),
+				) {
 					return
 				}
 			} else {
@@ -457,13 +481,19 @@ func TestGHIssue23(t *testing.T) {
 			Clock    Clock
 		}{
 			{
-				Expected: filepath.Join(dir, strings.ToLower(strings.Replace(locName, "/", "_", -1))+".201806010000.log"),
+				Expected: filepath.Join(
+					dir,
+					strings.ToLower(strings.Replace(locName, "/", "_", -1))+".201806010000.log",
+				),
 				Clock: ClockFunc(func() time.Time {
 					return time.Date(2018, 6, 1, 3, 18, 0, 0, loc)
 				}),
 			},
 			{
-				Expected: filepath.Join(dir, strings.ToLower(strings.Replace(locName, "/", "_", -1))+".201712310000.log"),
+				Expected: filepath.Join(
+					dir,
+					strings.ToLower(strings.Replace(locName, "/", "_", -1))+".201712310000.log",
+				),
 				Clock: ClockFunc(func() time.Time {
 					return time.Date(2017, 12, 31, 23, 52, 0, 0, loc)
 				}),
@@ -471,22 +501,25 @@ func TestGHIssue23(t *testing.T) {
 		}
 		for _, test := range tests {
 			test := test
-			t.Run(fmt.Sprintf("location = %s, time = %s", locName, test.Clock.Now().Format(time.RFC3339)), func(t *testing.T) {
-				template := strings.ToLower(strings.Replace(locName, "/", "_", -1)) + ".%Y%m%d%H%M.log"
-				rl, err := New(
-					filepath.Join(dir, template),
-					WithClock(test.Clock), // we're not using WithLocation, but it's the same thing
-				)
-				if !assert.NoError(t, err, "New should succeed") {
-					return
-				}
+			t.Run(
+				fmt.Sprintf("location = %s, time = %s", locName, test.Clock.Now().Format(time.RFC3339)),
+				func(t *testing.T) {
+					template := strings.ToLower(strings.Replace(locName, "/", "_", -1)) + ".%Y%m%d%H%M.log"
+					rl, err := New(
+						filepath.Join(dir, template),
+						WithClock(test.Clock), // we're not using WithLocation, but it's the same thing
+					)
+					if !assert.NoError(t, err, "New should succeed") {
+						return
+					}
 
-				t.Logf("expected %s", test.Expected)
-				assert.NoError(t, rl.Rotate())
-				if !assert.Equal(t, test.Expected, rl.CurrentFileName(), "file names should match") {
-					return
-				}
-			})
+					t.Logf("expected %s", test.Expected)
+					assert.NoError(t, rl.Rotate())
+					if !assert.Equal(t, test.Expected, rl.CurrentFileName(), "file names should match") {
+						return
+					}
+				},
+			)
 		}
 	}
 
@@ -535,7 +568,15 @@ func TestForceNewFile(t *testing.T) {
 				return
 			}
 			str := fmt.Sprintf("Hello, World%d", i)
-			if !assert.Equal(t, str, string(content), "read %s from file %s, not expected %s", string(content), rl.CurrentFileName(), str) {
+			if !assert.Equal(
+				t,
+				str,
+				string(content),
+				"read %s from file %s, not expected %s",
+				string(content),
+				rl.CurrentFileName(),
+				str,
+			) {
 				return
 			}
 
@@ -544,7 +585,14 @@ func TestForceNewFile(t *testing.T) {
 			if !assert.NoError(t, err, "os.ReadFile should succeed") {
 				return
 			}
-			if !assert.Equal(t, "Hello, World!", string(content), "read %s from file %s, not expected Hello, World!", string(content), baseFn) {
+			if !assert.Equal(
+				t,
+				"Hello, World!",
+				string(content),
+				"read %s from file %s, not expected Hello, World!",
+				string(content),
+				baseFn,
+			) {
 				return
 			}
 		}
@@ -573,7 +621,15 @@ func TestForceNewFile(t *testing.T) {
 				return
 			}
 			str := fmt.Sprintf("Hello, World%d", i)
-			if !assert.Equal(t, str, string(content), "read %s from file %s, not expected %s", string(content), rl.CurrentFileName(), str) {
+			if !assert.Equal(
+				t,
+				str,
+				string(content),
+				"read %s from file %s, not expected %s",
+				string(content),
+				rl.CurrentFileName(),
+				str,
+			) {
 				return
 			}
 
@@ -582,7 +638,133 @@ func TestForceNewFile(t *testing.T) {
 			if !assert.NoError(t, err, "os.ReadFile should succeed") {
 				return
 			}
-			if !assert.Equal(t, "Hello, World!", string(content), "read %s from file %s, not expected Hello, World!", string(content), baseFn) {
+			if !assert.Equal(
+				t,
+				"Hello, World!",
+				string(content),
+				"read %s from file %s, not expected Hello, World!",
+				string(content),
+				baseFn,
+			) {
+				return
+			}
+		}
+	})
+
+	assert.NoError(t, os.RemoveAll(dir))
+}
+
+func TestTimeBased(t *testing.T) {
+	dir, err := os.MkdirTemp("", "file-rotatelogs-time-based")
+	if !assert.NoError(t, err, `creating temporary directory should succeed`) {
+		return
+	}
+
+	loc, _ := time.LoadLocation("Asia/Tokyo")
+	date := time.Date(2024, 8, 6, 16, 42, 22, 0, loc)
+	clock := ClockFunc(func() time.Time {
+		return date
+	})
+
+	t.Run("Force a new file", func(t *testing.T) {
+
+		_, err := New(
+			filepath.Join(dir, "force-new-file.log"),
+			TimeBased(),
+			WithClock(clock),
+		)
+		assert.Error(t, err)
+
+		rl, err := New(
+			filepath.Join(dir, "force-new-file.log.%H%M%S"),
+			TimeBased(),
+			WithClock(clock),
+		)
+		if !assert.NoError(t, err, "New should succeed") {
+			return
+		}
+		_, _ = rl.Write([]byte("Hello, World!"))
+		_ = rl.Close()
+		date = date.Add(time.Second)
+		for i := 0; i < 10; i++ {
+			baseFn := filepath.Join(dir, "force-new-file.log.%H%M%S")
+			if !assert.NoError(t, err, "strftime pattern failed") {
+				return
+			}
+			rl, err := New(
+				baseFn,
+				TimeBased(),
+				WithClock(clock),
+			)
+			if !assert.NoError(t, err, "New should succeed") {
+				return
+			}
+			_, _ = rl.Write([]byte("Hello, World"))
+			_, _ = rl.Write([]byte(fmt.Sprintf("%d", i)))
+			_ = rl.Close()
+
+			fn := filepath.Base(rl.CurrentFileName())
+			suffix := strings.TrimPrefix(fn, "force-new-file.log")
+			expectedSuffix := fmt.Sprintf(".%d", 164223+i) // 16:42:23
+			if !assert.True(t, suffix == expectedSuffix, "expected suffix %s found %s", expectedSuffix, suffix) {
+				return
+			}
+			assert.FileExists(t, rl.CurrentFileName(), "file does not exist %s", rl.CurrentFileName())
+			content, err := os.ReadFile(rl.CurrentFileName())
+			if !assert.NoError(t, err, "os.ReadFile %s should succeed", rl.CurrentFileName()) {
+				return
+			}
+			str := fmt.Sprintf("Hello, World%d", i)
+			if !assert.Equal(
+				t,
+				str,
+				string(content),
+				"read %s from file %s, not expected %s",
+				string(content),
+				rl.CurrentFileName(),
+				str,
+			) {
+				return
+			}
+			date = date.Add(time.Second)
+		}
+	})
+
+	t.Run("Force a new file with Rotate", func(t *testing.T) {
+		baseFn := filepath.Join(dir, "force-new-file.log.%H%M%S")
+		rl, err := New(
+			baseFn,
+			TimeBased(),
+			WithClock(clock),
+		)
+		if !assert.NoError(t, err, "New should succeed") {
+			return
+		}
+		_, _ = rl.Write([]byte("Hello, World!"))
+
+		// start with 16:42:33
+		for i := 0; i < 10; i++ {
+			date = date.Add(time.Second)
+			if !assert.NoError(t, rl.Rotate(), "rl.Rotate should succeed") {
+				return
+			}
+			_, _ = rl.Write([]byte("Hello, World"))
+			_, _ = rl.Write([]byte(fmt.Sprintf("%d", i)))
+			assert.FileExists(t, rl.CurrentFileName(), "file does not exist %s", rl.CurrentFileName())
+			content, err := os.ReadFile(rl.CurrentFileName())
+			if !assert.NoError(t, err, "os.ReadFile %s should succeed", rl.CurrentFileName()) {
+				return
+			}
+			str := fmt.Sprintf("Hello, World%d", i)
+			if !assert.Equal(
+				t,
+				str,
+				string(content),
+				"read %s from file %s, not expected %s",
+				string(content),
+				rl.CurrentFileName(),
+				str,
+			) {
 				return
 			}
 		}

--- a/strftime/strftime_test.go
+++ b/strftime/strftime_test.go
@@ -187,7 +187,12 @@ func TestGHIssue5(t *testing.T) {
 	const expected = `apm-test/logs/apm.log.01000101`
 	p, _ := strftime.New("apm-test/logs/apm.log.%Y%m%d")
 	dt := time.Date(100, 1, 1, 1, 0, 0, 0, time.UTC)
-	if !assert.Equal(t, expected, p.FormatString(dt), `patterns including 'pm' should be treated as verbatim formatter`) {
+	if !assert.Equal(
+		t,
+		expected,
+		p.FormatString(dt),
+		`patterns including 'pm' should be treated as verbatim formatter`,
+	) {
 		return
 	}
 }
@@ -363,7 +368,15 @@ func TestGHIssue18(t *testing.T) {
 				buf.Reset()
 
 				assert.NoError(t, pattern.Format(&buf, testTime))
-				if !assert.Equal(t, correctString, buf.String(), "Buffer [%s] should be [%s] for time %s", buf.String(), correctString, testTime) {
+				if !assert.Equal(
+					t,
+					correctString,
+					buf.String(),
+					"Buffer [%s] should be [%s] for time %s",
+					buf.String(),
+					correctString,
+					testTime,
+				) {
 					return
 				}
 			}
@@ -393,7 +406,15 @@ func TestGHIssue18(t *testing.T) {
 
 			t.Logf("%s", correctString)
 			assert.NoError(t, pattern.Format(&buf, testTime))
-			if !assert.Equal(t, correctString, buf.String(), "Buffer [%s] should be [%s] for time %s", buf.String(), correctString, testTime) {
+			if !assert.Equal(
+				t,
+				correctString,
+				buf.String(),
+				"Buffer [%s] should be [%s] for time %s",
+				buf.String(),
+				correctString,
+				testTime,
+			) {
 				continue
 			}
 		}


### PR DESCRIPTION
In some cases, we prefer to create a log file with the file name generated using hours, minutes, and seconds.

The suffix .1, .2, .3, etc., is not needed in this case.

## 📑 Description

Log suffixes carrying time information can be used to organize and collect logs more conveniently.

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new option for log file generation that allows users to skip the generation of new log filenames, enhancing log management flexibility.
  - Added functionality for formatted log filenames, including timestamps with hours, minutes, and seconds.
  
- **Bug Fixes**
  - Enhanced error handling for log file creation when the skip generation option is used.

- **Documentation**
  - Updated README to include new features and usage examples related to log file naming conventions.

- **Tests**
  - Added tests for the new log generation functionalities and improved readability for existing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
